### PR TITLE
Tooltiptext

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ If you want to run the demo, clone the repository, perform an ```npm install```,
 To use this library, there are a handful of setup steps to go through that vary based on your app environment (e.g., Webpack, ngCli, SystemJS, etc.).
 Generally, the steps are:
 
-* Follow the instructions to install and configure [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet)
-* Install this library and the Leaflet-draw typings (see above).
-* Import the Leaflet and Leaflet-draw stylesheet
-* Import the ngx-leaflet and ngx-leaflet-draw modules into your Angular project
-* Create and configure a map (see docs below and/or demo)
-
+- Follow the instructions to install and configure [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet)
+- Install this library and the Leaflet-draw typings (see above).
+- Import the Leaflet and Leaflet-draw stylesheet
+- Import the ngx-leaflet and ngx-leaflet-draw modules into your Angular project
+- Create and configure a map (see docs below and/or demo)
 
 ### Import the Leaflet Stylesheet
 For leaflet to work, you need to have the leaflet stylesheets loaded into your application.
@@ -157,22 +156,23 @@ This leaflet draw plugin exposes the `L.Draw.Event`s found in the [leaflet draw 
 For a working example, check out the the demo.
 
 The following events are provided:
-* ```(leafletDrawCreated)```
-* ```(leafletDrawEdited)```
-* ```(leafletDrawDeleted)```
-* ```(leafletDrawStart)```
-* ```(leafletDrawStop)```
-* ```(leafletDrawVertex)```
-* ```(leafletDrawEditStart)```
-* ```(leafletDrawEditMove)```
-* ```(leafletDrawEditResize)```
-* ```(leafletDrawEditVertex)```
-* ```(leafletDrawEditStop)```
-* ```(leafletDrawDeleteStart)```
-* ```(leafletDrawDeleteStop)```
-* ```(leafletDrawToolbarOpened)```
-* ```(leafletDrawToolbarClosed)```
-* ```(leafletDrawMarkerContext)```
+
+- ```(leafletDrawCreated)```
+- ```(leafletDrawEdited)```
+- ```(leafletDrawDeleted)```
+- ```(leafletDrawStart)```
+- ```(leafletDrawStop)```
+- ```(leafletDrawVertex)```
+- ```(leafletDrawEditStart)```
+- ```(leafletDrawEditMove)```
+- ```(leafletDrawEditResize)```
+- ```(leafletDrawEditVertex)```
+- ```(leafletDrawEditStop)```
+- ```(leafletDrawDeleteStart)```
+- ```(leafletDrawDeleteStop)```
+- ```(leafletDrawToolbarOpened)```
+- ```(leafletDrawToolbarClosed)```
+- ```(leafletDrawMarkerContext)```
 
 ### Getting a Reference to the Draw Control
 Occasionally, you may need to directly access the Leaflet Draw Control instance.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install --save-dev @types/leaflet
 npm install --save-dev @types/leaflet-draw
 ```
 
-If you want to run the demo, clone the repository, perform an ```npm install```, ```npm run demo``` and then go to http://localhost:4200
+If you want to run the demo, clone the repository, perform an ```npm install```, ```npm run demo``` and then go to [http://localhost:4200](http://localhost:4200).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -111,17 +111,17 @@ drawOptions = {
    draw: {
       marker: {
          icon: L.icon({
-             iconSize: [ 25, 41 ],
-             iconAnchor: [ 13, 41 ],
-             iconUrl: 'assets/marker-icon.png',
-             shadowUrl: 'assets/marker-shadow.png'
+            iconSize: [ 25, 41 ],
+            iconAnchor: [ 13, 41 ],
+            iconUrl: 'assets/marker-icon.png',
+            shadowUrl: 'assets/marker-shadow.png'
          })
       },
       polyline: false,
       circle: {
-          shapeOptions: {
-              color: '#aaaaaa'
-          }
+         shapeOptions: {
+            color: '#aaaaaa'
+         }
       }
    }
 };

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [travis-url]: https://travis-ci.org/Asymmetrik/ngx-leaflet-draw/
 [travis-image]: https://travis-ci.org/Asymmetrik/ngx-leaflet-draw.svg
 
-*IMPORTANT NOTE: We have renamed this package from ```@asymmetrik/angular2-leaflet-draw``` to ```@asymmetrik/ngx-leaflet-draw```* 
+*IMPORTANT NOTE: We have renamed this package from ```@asymmetrik/angular2-leaflet-draw``` to ```@asymmetrik/ngx-leaflet-draw```*
 
 > Leaflet Draw extension to the @asymmetrik/ngx-leaflet package for Angular.io
 > Provides Leaflet Draw integration into Angular.io projects. Compatible with Leaflet v1.x and Leaflet Draw 0.4.x
@@ -52,7 +52,7 @@ Generally, the steps are:
 
 ### Import the Leaflet Stylesheet
 For leaflet to work, you need to have the leaflet stylesheets loaded into your application.
-If you've installed via npm, you will need to load ```./node_modules/leaflet/dist/leaflet.css``` and ```./node_modules/leaflet-draw/dist/leaflet.draw.css```. 
+If you've installed via npm, you will need to load ```./node_modules/leaflet/dist/leaflet.css``` and ```./node_modules/leaflet-draw/dist/leaflet.draw.css```.
 How you include the stylesheet will depend on your specific setup. For examples, refer to the [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet) README
 
 
@@ -66,7 +66,7 @@ Before you can use the module in your Angular.io app, you'll need to import it i
 Note that you also need to import the ngx-leaflet module as well.
 
 For example, in your ```app.module.ts```, add:
- 
+
 ```js
 import { LeafletModule } from '@asymmetrik/ngx-leaflet';
 import { LeafletDrawModule } from '@asymmetrik/ngx-leaflet-draw';
@@ -100,11 +100,11 @@ Finally, add the ```leafletDraw``` attribute directive to add the leaflet draw c
 ```
 
 #### leafletDraw
-This is an attribute directive that initiates the leaflet draw plugin. 
+This is an attribute directive that initiates the leaflet draw plugin.
 
 #### leafletDrawOptions
 Input binding for the options to be passed to the draw plugin upon creation.
-These options are only currently processed at creation time. 
+These options are only currently processed at creation time.
 
 ```js
 drawOptions = {
@@ -136,7 +136,7 @@ drawOptions = {
 The options object is passed through to the Leaflet.draw object.
 Therefore, you can reference [their documentation](https://github.com/Leaflet/Leaflet.draw) for help configuring the draw control.
 
-If you do not provide a ```featureGroup``` for the Leaflet.draw plugin to use, the leafletDraw directive will create one internally and put it in the options object. 
+If you do not provide a ```featureGroup``` for the Leaflet.draw plugin to use, the leafletDraw directive will create one internally and put it in the options object.
 
 #### drawToolbarTooltips
 
@@ -231,7 +231,7 @@ This will only work if your custom component/directive exists on the same DOM el
 })
 export class MyCustomDirective {
    leafletDrawDirective: LeafletDrawDirective;
-	
+
    constructor(leafletDrawDirective: LeafletDrawDirective) {
       this.leafletDrawDirective = leafletDrawDirective;
    }
@@ -269,7 +269,7 @@ When it evaluates to true, the child element is added to the map, which recreate
 ### A Note About Markers
 If you are using Angular CLI or Webpack to package your project, you will need to configure the marker icon as shown in the ```leafletDrawOptions``` example above.
 The issue has to do with how Leaflet handles icon image loading.
-For more details on how to set this up, reference the README from [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet#a-note-about-markers).  
+For more details on how to set this up, reference the README from [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet#a-note-about-markers).
 
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 > Now supports Angular v8, Ahead-of-Time compilation (AOT), and use in Angular-CLI based projects
 
 ## Table of Contents
+
 - [Install](#install)
 - [Usage](#usage)
 - [API](#api)
@@ -20,8 +21,8 @@
 - [License](#license)
 - [Credits](#credits)
 
-
 ## Install
+
 Install the package and its peer dependencies via npm (or yarn):
 
 ```shell
@@ -40,8 +41,8 @@ npm install --save-dev @types/leaflet-draw
 
 If you want to run the demo, clone the repository, perform an ```npm install```, ```npm run demo``` and then go to [http://localhost:4200](http://localhost:4200).
 
-
 ## Usage
+
 To use this library, there are a handful of setup steps to go through that vary based on your app environment (e.g., Webpack, ngCli, SystemJS, etc.).
 Generally, the steps are:
 
@@ -52,17 +53,18 @@ Generally, the steps are:
 - Create and configure a map (see docs below and/or demo)
 
 ### Import the Leaflet Stylesheet
+
 For leaflet to work, you need to have the leaflet stylesheets loaded into your application.
 If you've installed via npm, you will need to load ```./node_modules/leaflet/dist/leaflet.css``` and ```./node_modules/leaflet-draw/dist/leaflet.draw.css```.
 How you include the stylesheet will depend on your specific setup. For examples, refer to the [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet) README
 
-
 ### Import Code Dependencies and Module
+
 This project is exported using UMD and it includes typings.
 So, you shouldn't have to do anything special to use it if you're building your project in Typescript.
 
-
 #### Typescript Angular.io Module Import
+
 Before you can use the module in your Angular.io app, you'll need to import it in your application.
 Note that you also need to import the ngx-leaflet module as well.
 
@@ -82,11 +84,12 @@ imports: [
 ```
 
 #### Not Using Typescript?
+
 You brave soul.
 The code is exported using UMD (bundles are in the ./dist dir) so you should be able to import is using whatever module system/builder you're using, even if you aren't using Typescript.
 
-
 ### Create and Configure a Map with the Draw Controls
+
 To create a map, use the ```leaflet``` attribute directive. This directive must appear first.
 You must specify an initial zoom/center and set of layers either via ```leafletOptions``` or by binding to ```leafletZoom```, ```leafletCenter```, and ```leafletLayers```.
 Finally, add the ```leafletDraw``` attribute directive to add the leaflet draw control and configure it with ```leafletDrawOptions```.
@@ -101,9 +104,11 @@ Finally, add the ```leafletDraw``` attribute directive to add the leaflet draw c
 ```
 
 #### leafletDraw
+
 This is an attribute directive that initiates the leaflet draw plugin.
 
 #### leafletDrawOptions
+
 Input binding for the options to be passed to the draw plugin upon creation.
 These options are only currently processed at creation time.
 
@@ -154,6 +159,7 @@ drawToolbarTooltips = {
 ```
 
 ### Draw Events
+
 This leaflet draw plugin exposes the `L.Draw.Event`s found in the [leaflet draw documentation](http://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#l-draw-event).
 For a working example, check out the the demo.
 
@@ -177,6 +183,7 @@ The following events are provided:
 - ```(leafletDrawMarkerContext)```
 
 ### Getting a Reference to the Draw Control
+
 Occasionally, you may need to directly access the Leaflet Draw Control instance.
 For example, to dynamically change settings or change its behavior.
 There are a couple of different ways to achieve this depending on what you're trying to do.
@@ -187,8 +194,8 @@ This output is invoked after the map is created, the argument of the event being
 The second is to get a reference to the leaflet draw directive itself - and there are a couple of ways to do this.
 With a reference to the directive, you can invoke the ```getDrawControl()``` function to get a reference to the ```Control.Draw``` instance.
 
-
 #### leafletDrawReady
+
 This output is emitted when once when the Leaflet Draw Control is initially created inside of the Leaflet Draw directive.
 The event will only fire when the Control exists and is ready for manipulation.
 
@@ -210,8 +217,8 @@ onDrawReady(drawControl: Draw.Control) {
 This method of getting the draw control makes the most sense if you are using the Leaflet directive inside your own component
 and just need to add some limited functionality or register some event handlers.
 
-
 #### Inject LeafletDrawDirective into your Component
+
 In Angular.io, directives are injectable the same way that Services are.
 This means that you can create your own component or directive and inject the ```LeafletDrawDirective``` into it.
 This will only work if your custom component/directive exists on the same DOM element and is ordered after the injected LeafletDrawDirective, or if it is on a child DOM element.
@@ -248,8 +255,8 @@ export class MyCustomDirective {
 
 The benefit of this approach is it's a bit cleaner if you're interested in adding some reusable capability to the existing leaflet draw directive.
 
-
 ### Showing and Hiding the Draw Control
+
 If you want to toggle the draw control on and off, you can use the following approach:
 
 ```js
@@ -267,23 +274,22 @@ You can place the leafletDraw directive on a child element and then use *ngIf to
 When ngIf evaluates to false, the child element is removed from the map, which destroys the control.
 When it evaluates to true, the child element is added to the map, which recreates the control.
 
-
 ### A Note About Markers
+
 If you are using Angular CLI or Webpack to package your project, you will need to configure the marker icon as shown in the ```leafletDrawOptions``` example above.
 The issue has to do with how Leaflet handles icon image loading.
 For more details on how to set this up, reference the README from [@asymmetrik/ngx-leaflet](https://github.com/Asymmetrik/ngx-leaflet#a-note-about-markers).
 
-
 ## Contribute
+
 PRs accepted. If you are part of Asymmetrik, please make contributions on feature branches off of the ```develop``` branch.
 If you are outside of Asymmetrik, please fork our repo to make contributions and submit PRs against ```develop```.
 
-
 ## License
+
 See LICENSE in repository for details.
 
-
 ## Credits
+
 **[Leaflet](http://leafletjs.com/)** Is an awesome mapping package.
 **[Leaflet.draw](https://github.com/Leaflet/Leaflet.draw)** Makes drawing shapes on maps super easy.
-

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Finally, add the ```leafletDraw``` attribute directive to add the leaflet draw c
 <div leaflet style="height: 400px;"
      leafletDraw
      [leafletOptions]="options"
-     [leafletDrawOptions]="drawOptions">
+     [leafletDrawOptions]="drawOptions"
+     [leafletDrawToolbarTooltips]="drawToolbarTooltips">
 </div>
 ```
 
@@ -120,7 +121,12 @@ drawOptions = {
       polyline: false,
       circle: {
          shapeOptions: {
-            color: '#aaaaaa'
+            color: '#d4af37'
+         }
+      },
+      rectangle: {
+         shapeOptions: {
+            color: '#85bb65'
          }
       }
    }
@@ -131,6 +137,20 @@ The options object is passed through to the Leaflet.draw object.
 Therefore, you can reference [their documentation](https://github.com/Leaflet/Leaflet.draw) for help configuring the draw control.
 
 If you do not provide a ```featureGroup``` for the Leaflet.draw plugin to use, the leafletDraw directive will create one internally and put it in the options object. 
+
+#### drawToolbarTooltips
+
+This options object is separate from leafletDrawOptions because it is not
+passed through to the Leaflet.draw object but instead is translated into
+`L.drawLocal.draw.toolbar.buttons.*` values. This translation is only currently
+done at creation time.
+
+```js
+drawToolbarTooltips = {
+   circle: 'Draw coin',
+   rectangle: 'Draw banknote',
+};
+```
 
 ### Draw Events
 This leaflet draw plugin exposes the `L.Draw.Event`s found in the [leaflet draw documentation](http://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#l-draw-event).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 
 ## Install
 Install the package and its peer dependencies via npm (or yarn):
-```
+
+```shell
 npm install leaflet
 npm install leaflet-draw
 npm install @asymmetrik/ngx-leaflet
@@ -31,7 +32,8 @@ npm install @asymmetrik/ngx-leaflet-draw
 ```
 
 If you intend to use this library in a typescript project (utilizing the typings), you will need to also install the leaflet typings via npm:
-```
+
+```shell
 npm install --save-dev @types/leaflet
 npm install --save-dev @types/leaflet-draw
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { LeafletDrawModule } from './leaflet-draw/leaflet-draw.module';
-export { LeafletDrawDirective } from './leaflet-draw/core/leaflet-draw.directive';
+export { LeafletDrawDirective, DrawToolbarTooltips } from './leaflet-draw/core/leaflet-draw.directive';

--- a/src/leaflet-draw/core/leaflet-draw.directive.ts
+++ b/src/leaflet-draw/core/leaflet-draw.directive.ts
@@ -5,6 +5,38 @@ import 'leaflet-draw';
 
 import { LeafletDirective, LeafletDirectiveWrapper, LeafletUtil } from '@asymmetrik/ngx-leaflet';
 
+// tslint:disable-next-line:interface-name
+interface DrawToolbarTooltips {
+	/**
+	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.circle.
+	 */
+	circle?: string;
+
+	/**
+	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.circlemarker.
+	 */
+	circlemarker?: string;
+
+	/**
+	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.marker.
+	 */
+	marker?: string;
+
+	/**
+	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.polygon.
+	 */
+	polygon?: string;
+
+	/**
+	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.polyline.
+	 */
+	polyline?: string;
+
+	/**
+	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.rectangle.
+	 */
+	rectangle?: string;
+}
 
 @Directive({
 	selector: '[leafletDraw]'
@@ -18,6 +50,7 @@ export class LeafletDrawDirective
 	featureGroup: L.FeatureGroup;
 
 	@Input('leafletDrawOptions') drawOptions: L.Control.DrawConstructorOptions = null;
+	@Input('leafletDrawToolbarTooltips') drawToolbarTooltips: DrawToolbarTooltips = null;
 
 	// Configure callback function for the map
 	@Output('leafletDrawReady') drawReady = new EventEmitter<L.Control.Draw>();
@@ -49,6 +82,10 @@ export class LeafletDrawDirective
 
 		// Initialize the draw options (in case they weren't provided)
 		this.drawOptions = this.initializeDrawOptions(this.drawOptions);
+
+		// Initialize L.drawLocal.draw.toolbar.buttons.* values.
+		// Must be done before "new L.Control.Draw".
+		this.initializeToolbarTooltips(this.drawToolbarTooltips);
 
 		// Create the control
 		this.drawControl =  new L.Control.Draw(this.drawOptions);
@@ -85,6 +122,34 @@ export class LeafletDrawDirective
 
 		// Notify others that the draw control has been created
 		this.drawReady.emit(this.drawControl);
+	}
+
+	// This performes tooltip customization like described in Leaflet.draw/docs/examples/basic.html:
+	//     L.drawLocal.draw.toolbar.buttons.polygon = 'Draw a sexy polygon!';
+	//     var drawControl = new L.Control.Draw({ ...
+	initializeToolbarTooltips(drawToolbarTooltips: DrawToolbarTooltips): void {
+		if (!drawToolbarTooltips) {
+			return;
+		}
+		const buttons = (L as any).drawLocal.draw.toolbar.buttons;
+		if (drawToolbarTooltips.circle) {
+			buttons.circle = drawToolbarTooltips.circle;
+		}
+		if (drawToolbarTooltips.circlemarker) {
+			buttons.circlemarker = drawToolbarTooltips.circlemarker;
+		}
+		if (drawToolbarTooltips.marker) {
+			buttons.marker = drawToolbarTooltips.marker;
+		}
+		if (drawToolbarTooltips.polygon) {
+			buttons.polygon = drawToolbarTooltips.polygon;
+		}
+		if (drawToolbarTooltips.polyline) {
+			buttons.polyline = drawToolbarTooltips.polyline;
+		}
+		if (drawToolbarTooltips.rectangle) {
+			buttons.rectangle = drawToolbarTooltips.rectangle;
+		}
 	}
 
 	ngOnDestroy() {

--- a/src/leaflet-draw/core/leaflet-draw.directive.ts
+++ b/src/leaflet-draw/core/leaflet-draw.directive.ts
@@ -6,7 +6,7 @@ import 'leaflet-draw';
 import { LeafletDirective, LeafletDirectiveWrapper, LeafletUtil } from '@asymmetrik/ngx-leaflet';
 
 // tslint:disable-next-line:interface-name
-interface DrawToolbarTooltips {
+export interface DrawToolbarTooltips {
 	/**
 	 * Tooltip string for L.drawLocal.draw.toolbar.buttons.circle.
 	 */


### PR DESCRIPTION
Add support for customizing the tooltip text for the draw toolbar buttons.

Let me know if you want the general markdown fixes in the readme file as a separate pull request instead.
